### PR TITLE
feat: Create V3 of robot control firmware

### DIFF
--- a/PID_Control_V3.ino
+++ b/PID_Control_V3.ino
@@ -1,66 +1,65 @@
 /*
- * main_feedback_control.ino
- * เฟิร์มแวร์สำหรับหุ่นยนต์ Mecanum 4 ล้อ 
+ * PID_Control_V3.ino
+ * เฟิร์มแวร์สำหรับหุ่นยนต์ Mecanum 4 ล้อ (ใช้ PID Controller Library)
+ * V3: ปรับโครงสร้างใช้ไลบรารี, เพิ่ม Deadzone, และปรับปรุงการ Reset
  *
  * หลักการทำงาน:
- * 1.  อ่านค่าจากรีโมทเพื่อกำหนด "ความเร็วเป้าหมาย" (Setpoint) ในหน่วย ticks/sec
+ * 1.  อ่านค่าจากรีโมทเพื่อกำหนด "ความเร็วเป้าหมาย" (Setpoint)
  * 2.  อ่านค่าจาก Encoder เพื่อหา "ความเร็วจริง" (Current Speed)
- * 3.  คำนวณหาค่าความผิดพลาด (Error = Setpoint - Current Speed)
- * 4.  นำค่า Error มาปรับแก้ค่า PWM ที่ส่งให้มอเตอร์อย่างต่อเนื่อง
- * - ถ้าหมุนช้าไป PWM จะเพิ่มขึ้น
- * - ถ้าหมุนเร็วไป PWM จะลดลง
- * 5.  ผลลัพธ์คือระบบควบคุมแบบ Closed-loop ที่เรียบง่าย (คล้าย Integral Controller)
- * ซึ่งพยายามรักษารอบหมุนให้ได้ตามเป้าหมาย
+ * 3.  ใช้ไลบรารี PIDController เพื่อคำนวณค่า PWM ที่เหมาะสม
+ * 4.  จัดการ Failsafe, Deadzone, และการ Reset สถานะของ PID อย่างถูกต้อง
  */
 
 // --- 1. รวมไลบรารีที่จำเป็น ---
 #include "Encoder.h"
 #include "IBT2_MotorDriver.h"
 #include "FlySkyi6Remote.h"
+#include "PIDController.h" // V3 Added
 
 // --- 2. การกำหนดค่าขา (Pin Definitions) ---
-// ล้อหน้าซ้าย (Front Left)
+// (เหมือนเดิม)
 #define FL_ENC_A PA2
 #define FL_ENC_B PA3
 #define FL_MOTOR_RPWM PA8
 #define FL_MOTOR_LPWM PB6
 #define FL_MOTOR_IS PA0
-// ล้อหน้าขวา (Front Right)
 #define FR_ENC_A PA4
 #define FR_ENC_B PA5
 #define FR_MOTOR_RPWM PB7
 #define FR_MOTOR_LPWM PB8
 #define FR_MOTOR_IS PA1
-// ล้อหลังซ้าย (Back Left)
 #define BL_ENC_A PB12
 #define BL_ENC_B PB13
 #define BL_MOTOR_RPWM PB9
 #define BL_MOTOR_LPWM PA15
 #define BL_MOTOR_IS PA6
-// ล้อหลังขวา (Back Right)
 #define BR_ENC_A PB14
 #define BR_ENC_B PB15
 #define BR_MOTOR_RPWM PB0
 #define BR_MOTOR_LPWM PB1
 #define BR_MOTOR_IS PA7
-
-// อุปกรณ์เสริม
 #define PUMP_PIN PC13
 
 // --- 3. ค่าคงที่และตัวแปรทั่วไป ---
 const int SWITCH_MID_THRESHOLD = 1500;
 const int SWITCH_LOW_THRESHOLD = 1200;
+const int LOW_GEAR_SPEED = 2400;  // ticks/sec
+const int HIGH_GEAR_SPEED = 4800; // ticks/sec
 
-// ค่าความเร็วสูงสุดในหน่วย (ticks/sec) สำหรับแต่ละเกียร์
-const int LOW_GEAR_SPEED = 2400;  // เกียร์ช้า
-const int HIGH_GEAR_SPEED = 4800; // เกียร์เร็ว
-
-// Gain สำหรับการปรับแก้ PWM (คล้าย Ki ใน PID)
-// - ค่ามากไป: ระบบจะสั่น (Overshoot)
-// - ค่าน้อยไป: ระบบจะตอบสนองช้า
-const float K_ADJUST = 0.005;
+// --- CHANGED: PI Controller Gains ---
+// ปรับค่า Kp เพื่อให้หุ่นตอบสนองเร็วขึ้น (เริ่มจากค่าน้อยๆ เช่น 0.05)
+// ปรับค่า Ki เพื่อลดความคลาดเคลื่อนเมื่อวิ่งคงที่ (เริ่มจากค่าน้อยๆ เช่น 0.005)
+const float Kp = 0.05; // Proportional Gain
+const float Ki = 0.008; // Integral Gain
+// --- END CHANGED ---
 
 const unsigned long LOOP_INTERVAL_US = 10000; // 100 Hz control loop
+
+// --- ADDED: Fail-safe Timeout ---
+const unsigned long REMOTE_TIMEOUT_MS = 200; // หยุดมอเตอร์ถ้าไม่ได้รับสัญญาณใหม่ใน 200 ms
+const int JOYSTICK_DEADZONE = 5; // V3 Added
+unsigned long lastRemoteReadTime = 0;
+// --- END ADDED ---
 
 // --- 4. การสร้างอ็อบเจกต์ ---
 Encoder encoder_FL(FL_ENC_A, FL_ENC_B);
@@ -76,13 +75,29 @@ IBT2_MotorDriver motor_BR(BR_MOTOR_RPWM, BR_MOTOR_LPWM, BR_MOTOR_IS);
 FlySkyi6Remote remote(Serial1);
 RemoteState remote_state;
 
+// --- V3 MODIFIED: Create PID Controller objects ---
+// สร้าง PID controller สำหรับแต่ละล้อ โดยใช้ค่า Kp, Ki ที่กำหนดไว้ และ Kd=0
+// Output Min/Max ถูกตั้งเป็น -255/255 ซึ่งเป็นค่า PWM
+PIDController pid_FL(Kp, Ki, 0, -255, 255);
+PIDController pid_FR(Kp, Ki, 0, -255, 255);
+PIDController pid_BL(Kp, Ki, 0, -255, 255);
+PIDController pid_BR(Kp, Ki, 0, -255, 255);
+// --- END V3 MODIFIED ---
+
 // --- 5. ตัวแปรสำหรับลูปควบคุม ---
 unsigned long lastRunTime = 0;
 long prevPos_FL = 0, prevPos_FR = 0, prevPos_BL = 0, prevPos_BR = 0;
 unsigned long prevTime = 0;
 
-// ตัวแปรสำหรับเก็บค่า PWM ของแต่ละล้อ
-float output_pwm_FL = 0, output_pwm_FR = 0, output_pwm_BL = 0, output_pwm_BR = 0;
+
+// --- V3 ADDED: Helper function for deadzone ---
+int apply_deadzone(int value, int deadzone) {
+    if (abs(value) <= deadzone) {
+        return 0;
+    }
+    return value;
+}
+// --- END V3 ADDED ---
 
 // --- 6. ฟังก์ชันสำหรับ Interrupt (ISR) ---
 void isr_FL() { encoder_FL.update(); }
@@ -105,54 +120,66 @@ void setup() {
     attachInterrupt(digitalPinToInterrupt(FR_ENC_A), isr_FR, CHANGE);
     attachInterrupt(digitalPinToInterrupt(BL_ENC_A), isr_BL, CHANGE);
     attachInterrupt(digitalPinToInterrupt(BR_ENC_A), isr_BR, CHANGE);
-
+    
     prevTime = micros();
+    // --- ADDED: Initialize remote read time ---
+    lastRemoteReadTime = millis();
+    // --- END ADDED ---
 }
 
 // ==================== MAIN LOOP ====================
 void loop() {
-    if (!remote.read(remote_state)) {
-        motor_FL.stop(); motor_FR.stop();
-        motor_BL.stop(); motor_BR.stop();
-        return;
+    // --- V3 MODIFIED: Remote Reading & Failsafe ---
+    if (remote.read(remote_state)) {
+        lastRemoteReadTime = millis();
     }
 
     bool is_armed = (remote_state.switch_B < SWITCH_LOW_THRESHOLD);
-    if (!is_armed) {
-        // Reset PWM values when disarmed
-        output_pwm_FL = 0; output_pwm_FR = 0;
-        output_pwm_BL = 0; output_pwm_BR = 0;
+
+    // ตรวจสอบ Failsafe หรือ Disarm
+    if ((millis() - lastRemoteReadTime > REMOTE_TIMEOUT_MS) || !is_armed) {
+        pid_FL.reset(); pid_FR.reset();
+        pid_BL.reset(); pid_BR.reset();
         motor_FL.stop(); motor_FR.stop();
         motor_BL.stop(); motor_BR.stop();
         return;
     }
+    // --- END V3 MODIFIED ---
 
-    // คำนวณความเร็วเป้าหมาย (Setpoint) จากรีโมท
+    // --- V3 MODIFIED: Apply deadzone and calculate setpoint ---
+    int stick_y_raw = apply_deadzone(remote_state.right_stick_y, JOYSTICK_DEADZONE);
+    int stick_x_raw = apply_deadzone(remote_state.right_stick_x, JOYSTICK_DEADZONE);
+    int stick_yaw_raw = apply_deadzone(remote_state.left_stick_x, JOYSTICK_DEADZONE);
+
+    // ถ้า Joystick อยู่ตรงกลาง, reset PID และหยุด
+    if (stick_y_raw == 0 && stick_x_raw == 0 && stick_yaw_raw == 0) {
+        pid_FL.reset(); pid_FR.reset();
+        pid_BL.reset(); pid_BR.reset();
+    }
+
     int max_speed = (remote_state.switch_B < SWITCH_MID_THRESHOLD) ? LOW_GEAR_SPEED : HIGH_GEAR_SPEED;
-    int stick_y = map(remote_state.right_stick_y, -100, 100, -max_speed, max_speed);
-    int stick_x = map(remote_state.right_stick_x, -100, 100, -max_speed, max_speed);
-    int stick_yaw = map(remote_state.left_stick_x, -100, 100, -max_speed, max_speed);
+    int stick_y = map(stick_y_raw, -100, 100, -max_speed, max_speed);
+    int stick_x = map(stick_x_raw, -100, 100, -max_speed, max_speed);
+    int stick_yaw = map(stick_yaw_raw, -100, 100, -max_speed, max_speed);
 
     float setpoint_FL = stick_y + stick_x + stick_yaw;
     float setpoint_FR = stick_y - stick_x - stick_yaw;
     float setpoint_BL = stick_y - stick_x + stick_yaw;
     float setpoint_BR = stick_y + stick_x - stick_yaw;
+    // --- END V3 MODIFIED ---
 
-    // จัดการฟังก์ชันปั๊มน้ำ
-    // (Logic for pump remains the same)
+    // (Pump logic can be placed here)
 
     // --- ลูปควบคุม (ทำงานที่ความถี่คงที่) ---
     unsigned long currentTime = micros();
     if (currentTime - lastRunTime >= LOOP_INTERVAL_US) {
         lastRunTime = currentTime;
-
-        // อ่านค่าตำแหน่งปัจจุบันจาก Encoder
+        
         long currentPos_FL = encoder_FL.getPosition();
         long currentPos_FR = encoder_FR.getPosition();
         long currentPos_BL = encoder_BL.getPosition();
         long currentPos_BR = encoder_BR.getPosition();
 
-        // คำนวณความเร็วจริง (Current Speed)
         unsigned long deltaTime = currentTime - prevTime;
         float current_speed_FL = 0, current_speed_FR = 0, current_speed_BL = 0, current_speed_BR = 0;
         if (deltaTime > 0) {
@@ -165,29 +192,16 @@ void loop() {
         prevPos_BL = currentPos_BL; prevPos_BR = currentPos_BR;
         prevTime = currentTime;
 
-        // --- หัวใจของระบบควบคุม: ปรับแก้ PWM จากค่า Error ---
-        // 1. คำนวณ Error
-        float error_FL = setpoint_FL - current_speed_FL;
-        float error_FR = setpoint_FR - current_speed_FR;
-        float error_BL = setpoint_BL - current_speed_BL;
-        float error_BR = setpoint_BR - current_speed_BR;
-
-        // 2. ปรับค่า PWM เดิมด้วยค่า Error ที่ปรับแก้ด้วย Gain
-        output_pwm_FL += K_ADJUST * error_FL;
-        output_pwm_FR += K_ADJUST * error_FR;
-        output_pwm_BL += K_ADJUST * error_BL;
-        output_pwm_BR += K_ADJUST * error_BR;
+        // --- V3 MODIFIED: Use PID Library to compute output ---
+        float pwm_FL = pid_FL.compute(setpoint_FL, current_speed_FL);
+        float pwm_FR = pid_FR.compute(setpoint_FR, current_speed_FR);
+        float pwm_BL = pid_BL.compute(setpoint_BL, current_speed_BL);
+        float pwm_BR = pid_BR.compute(setpoint_BR, current_speed_BR);
         
-        // 3. ป้องกันค่า PWM ไม่ให้เกินขอบเขต (Anti-windup)
-        output_pwm_FL = constrain(output_pwm_FL, -255, 255);
-        output_pwm_FR = constrain(output_pwm_FR, -255, 255);
-        output_pwm_BL = constrain(output_pwm_BL, -255, 255);
-        output_pwm_BR = constrain(output_pwm_BR, -255, 255);
-
-        // 4. สั่งขับเคลื่อนมอเตอร์ด้วยค่า PWM ที่ปรับแก้แล้ว
-        motor_FL.drive(output_pwm_FL);
-        motor_FR.drive(output_pwm_FR);
-        motor_BL.drive(output_pwm_BL);
-        motor_BR.drive(output_pwm_BR);
+        motor_FL.drive(pwm_FL);
+        motor_FR.drive(pwm_FR);
+        motor_BL.drive(pwm_BL);
+        motor_BR.drive(pwm_BR);
+        // --- END V3 MODIFIED ---
     }
 }

--- a/SimpleFeedbackControlV3.ino
+++ b/SimpleFeedbackControlV3.ino
@@ -1,16 +1,17 @@
 /*
- * main_feedback_control_v2_corrected.ino
- * เฟิร์มแวร์สำหรับหุ่นยนต์ Mecanum 4 ล้อ (ปรับปรุงเป็น PI Controller)
+ * SimpleFeedbackControlV3.ino
+ * เฟิร์มแวร์สำหรับหุ่นยนต์ Mecanum 4 ล้อ (Simple Feedback)
+ * V3: แก้ไขบั๊ก, เพิ่ม Failsafe, Joystick Deadzone, และ Integral Reset
  *
  * หลักการทำงาน:
- * 1.  อ่านค่าจากรีโมทเพื่อกำหนด "ความเร็วเป้าหมาย" (Setpoint)
+ * 1.  อ่านค่าจากรีโมทเพื่อกำหนด "ความเร็วเป้าหมาย" (Setpoint) ในหน่วย ticks/sec
  * 2.  อ่านค่าจาก Encoder เพื่อหา "ความเร็วจริง" (Current Speed)
  * 3.  คำนวณหาค่าความผิดพลาด (Error = Setpoint - Current Speed)
- * 4.  คำนวณค่า PWM จากระบบควบคุมแบบ PI Controller:
- * - P (Proportional): ตอบสนองทันทีตามขนาดของ Error (Kp * error)
- * - I (Integral): ค่อยๆ ปรับแก้เพื่อลด Error ที่ค้างอยู่ (Ki * integral_of_error)
- * - Output PWM = P + I
- * 5.  เพิ่ม Failsafe กรณีสัญญาณรีโมทขาดหาย
+ * 4.  นำค่า Error มาปรับแก้ค่า PWM ที่ส่งให้มอเตอร์อย่างต่อเนื่อง
+ * - ถ้าหมุนช้าไป PWM จะเพิ่มขึ้น
+ * - ถ้าหมุนเร็วไป PWM จะลดลง
+ * 5.  ผลลัพธ์คือระบบควบคุมแบบ Closed-loop ที่เรียบง่าย (คล้าย Integral Controller)
+ * ซึ่งพยายามรักษารอบหมุนให้ได้ตามเป้าหมาย
  */
 
 // --- 1. รวมไลบรารีที่จำเป็น ---
@@ -19,48 +20,53 @@
 #include "FlySkyi6Remote.h"
 
 // --- 2. การกำหนดค่าขา (Pin Definitions) ---
-// (เหมือนเดิม)
+// ล้อหน้าซ้าย (Front Left)
 #define FL_ENC_A PA2
 #define FL_ENC_B PA3
 #define FL_MOTOR_RPWM PA8
 #define FL_MOTOR_LPWM PB6
 #define FL_MOTOR_IS PA0
+// ล้อหน้าขวา (Front Right)
 #define FR_ENC_A PA4
 #define FR_ENC_B PA5
 #define FR_MOTOR_RPWM PB7
 #define FR_MOTOR_LPWM PB8
 #define FR_MOTOR_IS PA1
+// ล้อหลังซ้าย (Back Left)
 #define BL_ENC_A PB12
 #define BL_ENC_B PB13
 #define BL_MOTOR_RPWM PB9
 #define BL_MOTOR_LPWM PA15
 #define BL_MOTOR_IS PA6
+// ล้อหลังขวา (Back Right)
 #define BR_ENC_A PB14
 #define BR_ENC_B PB15
 #define BR_MOTOR_RPWM PB0
 #define BR_MOTOR_LPWM PB1
 #define BR_MOTOR_IS PA7
+
+// อุปกรณ์เสริม
 #define PUMP_PIN PC13
 
 // --- 3. ค่าคงที่และตัวแปรทั่วไป ---
 const int SWITCH_MID_THRESHOLD = 1500;
 const int SWITCH_LOW_THRESHOLD = 1200;
-const int LOW_GEAR_SPEED = 2400;  // ticks/sec
-const int HIGH_GEAR_SPEED = 4800; // ticks/sec
 
-// --- CHANGED: PI Controller Gains ---
-// ปรับค่า Kp เพื่อให้หุ่นตอบสนองเร็วขึ้น (เริ่มจากค่าน้อยๆ เช่น 0.05)
-// ปรับค่า Ki เพื่อลดความคลาดเคลื่อนเมื่อวิ่งคงที่ (เริ่มจากค่าน้อยๆ เช่น 0.005)
-const float Kp = 0.05; // Proportional Gain
-const float Ki = 0.008; // Integral Gain
-// --- END CHANGED ---
+// --- V3 ADDED: Failsafe and Deadzone ---
+const unsigned long REMOTE_TIMEOUT_MS = 200; // หยุดมอเตอร์ถ้าไม่ได้รับสัญญาณใหม่ใน 200 ms
+const int JOYSTICK_DEADZONE = 5;
+// --- END V3 ADDED ---
+
+// ค่าความเร็วสูงสุดในหน่วย (ticks/sec) สำหรับแต่ละเกียร์
+const int LOW_GEAR_SPEED = 2400;  // เกียร์ช้า
+const int HIGH_GEAR_SPEED = 4800; // เกียร์เร็ว
+
+// Gain สำหรับการปรับแก้ PWM (คล้าย Ki ใน PID)
+// - ค่ามากไป: ระบบจะสั่น (Overshoot)
+// - ค่าน้อยไป: ระบบจะตอบสนองช้า
+const float K_ADJUST = 0.005;
 
 const unsigned long LOOP_INTERVAL_US = 10000; // 100 Hz control loop
-
-// --- ADDED: Fail-safe Timeout ---
-const unsigned long REMOTE_TIMEOUT_MS = 200; // หยุดมอเตอร์ถ้าไม่ได้รับสัญญาณใหม่ใน 200 ms
-unsigned long lastRemoteReadTime = 0;
-// --- END ADDED ---
 
 // --- 4. การสร้างอ็อบเจกต์ ---
 Encoder encoder_FL(FL_ENC_A, FL_ENC_B);
@@ -77,14 +83,22 @@ FlySkyi6Remote remote(Serial1);
 RemoteState remote_state;
 
 // --- 5. ตัวแปรสำหรับลูปควบคุม ---
+unsigned long lastRemoteReadTime = 0; // V3 Added
 unsigned long lastRunTime = 0;
 long prevPos_FL = 0, prevPos_FR = 0, prevPos_BL = 0, prevPos_BR = 0;
 unsigned long prevTime = 0;
 
-// --- CHANGED: Variables for PI controller ---
-// เปลี่ยนชื่อเพื่อความชัดเจน ทำหน้าที่เก็บค่าผลรวมของ Error (Integral Term)
-float integral_term_FL = 0, integral_term_FR = 0, integral_term_BL = 0, integral_term_BR = 0;
-// --- END CHANGED ---
+// ตัวแปรสำหรับเก็บค่า PWM ของแต่ละล้อ
+float output_pwm_FL = 0, output_pwm_FR = 0, output_pwm_BL = 0, output_pwm_BR = 0;
+
+// --- V3 ADDED: Helper function for deadzone ---
+int apply_deadzone(int value, int deadzone) {
+    if (abs(value) <= deadzone) {
+        return 0;
+    }
+    return value;
+}
+// --- END V3 ADDED ---
 
 // --- 6. ฟังก์ชันสำหรับ Interrupt (ISR) ---
 void isr_FL() { encoder_FL.update(); }
@@ -107,49 +121,56 @@ void setup() {
     attachInterrupt(digitalPinToInterrupt(FR_ENC_A), isr_FR, CHANGE);
     attachInterrupt(digitalPinToInterrupt(BL_ENC_A), isr_BL, CHANGE);
     attachInterrupt(digitalPinToInterrupt(BR_ENC_A), isr_BR, CHANGE);
-    
+
     prevTime = micros();
-    // --- ADDED: Initialize remote read time ---
-    lastRemoteReadTime = millis();
-    // --- END ADDED ---
+    lastRemoteReadTime = millis(); // V3 Added: Initialize failsafe timer
 }
 
 // ==================== MAIN LOOP ====================
 void loop() {
-    // --- UPDATED LOGIC FOR REMOTE READING & FAILSAFE ---
+    // --- V3 MODIFIED: Remote Reading & Failsafe ---
     if (remote.read(remote_state)) {
         lastRemoteReadTime = millis(); // อัปเดตเวลาเมื่ออ่านสำเร็จ
     }
 
-    if (millis() - lastRemoteReadTime > REMOTE_TIMEOUT_MS) {
-        // หยุดมอเตอร์ทั้งหมดถ้าสัญญาณขาด
-        motor_FL.stop(); motor_FR.stop();
-        motor_BL.stop(); motor_BR.stop();
-        return; 
-    }
-    // --- END UPDATED LOGIC ---
-
     bool is_armed = (remote_state.switch_B < SWITCH_LOW_THRESHOLD);
-    if (!is_armed) {
-        // Reset integral terms when disarmed to prevent sudden movements
-        integral_term_FL = 0; integral_term_FR = 0;
-        integral_term_BL = 0; integral_term_BR = 0;
-        
+
+    // ตรวจสอบ Failsafe หรือ Disarm: ถ้าอย่างใดอย่างหนึ่งเป็นจริง ให้หยุดทุกอย่าง
+    if ((millis() - lastRemoteReadTime > REMOTE_TIMEOUT_MS) || !is_armed) {
+        // Reset PWM values (Integral term)
+        output_pwm_FL = 0; output_pwm_FR = 0;
+        output_pwm_BL = 0; output_pwm_BR = 0;
+        // Stop motors
         motor_FL.stop(); motor_FR.stop();
         motor_BL.stop(); motor_BR.stop();
-        return;
+        return; // ออกจาก loop เพื่อรอสถานะปกติ
     }
+    // --- END V3 MODIFIED ---
+
+    // --- V3 MODIFIED: Apply deadzone and calculate setpoint ---
+    int stick_y_raw = apply_deadzone(remote_state.right_stick_y, JOYSTICK_DEADZONE);
+    int stick_x_raw = apply_deadzone(remote_state.right_stick_x, JOYSTICK_DEADZONE);
+    int stick_yaw_raw = apply_deadzone(remote_state.left_stick_x, JOYSTICK_DEADZONE);
 
     // คำนวณความเร็วเป้าหมาย (Setpoint) จากรีโมท
     int max_speed = (remote_state.switch_B < SWITCH_MID_THRESHOLD) ? LOW_GEAR_SPEED : HIGH_GEAR_SPEED;
-    int stick_y = map(remote_state.right_stick_y, -100, 100, -max_speed, max_speed);
-    int stick_x = map(remote_state.right_stick_x, -100, 100, -max_speed, max_speed);
-    int stick_yaw = map(remote_state.left_stick_x, -100, 100, -max_speed, max_speed);
+    int stick_y = map(stick_y_raw, -100, 100, -max_speed, max_speed);
+    int stick_x = map(stick_x_raw, -100, 100, -max_speed, max_speed);
+    int stick_yaw = map(stick_yaw_raw, -100, 100, -max_speed, max_speed);
 
     float setpoint_FL = stick_y + stick_x + stick_yaw;
     float setpoint_FR = stick_y - stick_x - stick_yaw;
     float setpoint_BL = stick_y - stick_x + stick_yaw;
     float setpoint_BR = stick_y + stick_x - stick_yaw;
+    // --- END V3 MODIFIED ---
+
+    // --- V3 ADDED: Reset Integral when sticks are centered ---
+    // ถ้าไม่มีคำสั่งเคลื่อนที่ ให้รีเซ็ตค่า PWM ที่สะสมไว้เพื่อป้องกันการ "ไหล"
+    if (stick_y_raw == 0 && stick_x_raw == 0 && stick_yaw_raw == 0) {
+        output_pwm_FL = 0; output_pwm_FR = 0;
+        output_pwm_BL = 0; output_pwm_BR = 0;
+    }
+    // --- END V3 ADDED ---
 
     // (Pump logic can be placed here)
 
@@ -157,7 +178,7 @@ void loop() {
     unsigned long currentTime = micros();
     if (currentTime - lastRunTime >= LOOP_INTERVAL_US) {
         lastRunTime = currentTime;
-        
+
         long currentPos_FL = encoder_FL.getPosition();
         long currentPos_FR = encoder_FR.getPosition();
         long currentPos_BL = encoder_BL.getPosition();
@@ -175,38 +196,21 @@ void loop() {
         prevPos_BL = currentPos_BL; prevPos_BR = currentPos_BR;
         prevTime = currentTime;
 
-        // --- HEART OF THE PI CONTROLLER ---
-        // 1. คำนวณ Error
         float error_FL = setpoint_FL - current_speed_FL;
         float error_FR = setpoint_FR - current_speed_FR;
         float error_BL = setpoint_BL - current_speed_BL;
         float error_BR = setpoint_BR - current_speed_BR;
 
-        // 2. คำนวณ Integral Term (พร้อม Anti-windup)
-        integral_term_FL += Ki * error_FL;
-        integral_term_FR += Ki * error_FR;
-        integral_term_BL += Ki * error_BL;
-        integral_term_BR += Ki * error_BR;
+        output_pwm_FL += K_ADJUST * error_FL;
+        output_pwm_FR += K_ADJUST * error_FR;
+        output_pwm_BL += K_ADJUST * error_BL;
+        output_pwm_BR += K_ADJUST * error_BR;
         
-        // จำกัดค่า Integral Term เพื่อป้องกัน "Integral Windup"
-        integral_term_FL = constrain(integral_term_FL, -200, 200);
-        integral_term_FR = constrain(integral_term_FR, -200, 200);
-        integral_term_BL = constrain(integral_term_BL, -200, 200);
-        integral_term_BR = constrain(integral_term_BR, -200, 200);
-
-        // 3. คำนวณ Final Output PWM จาก P-Term และ I-Term
-        float output_pwm_FL = (Kp * error_FL) + integral_term_FL;
-        float output_pwm_FR = (Kp * error_FR) + integral_term_FR;
-        float output_pwm_BL = (Kp * error_BL) + integral_term_BL;
-        float output_pwm_BR = (Kp * error_BR) + integral_term_BR;
-
-        // 4. จำกัดค่า PWM สุดท้ายให้อยู่ในช่วง -255 ถึง 255
         output_pwm_FL = constrain(output_pwm_FL, -255, 255);
         output_pwm_FR = constrain(output_pwm_FR, -255, 255);
         output_pwm_BL = constrain(output_pwm_BL, -255, 255);
         output_pwm_BR = constrain(output_pwm_BR, -255, 255);
-        
-        // 5. สั่งขับเคลื่อนมอเตอร์
+
         motor_FL.drive(output_pwm_FL);
         motor_FR.drive(output_pwm_FR);
         motor_BL.drive(output_pwm_BL);


### PR DESCRIPTION
This commit introduces V3 of the three main firmware files for the Mecanum robot, addressing stability issues and improving overall robustness.

- **DirecControlV3.ino:** Added a joystick deadzone to prevent drift and improve control precision when stopping.

- **SimpleFeedbackControlV3.ino:** Fixed a critical bug that caused wheels to keep spinning.
  - Implemented a remote signal failsafe timeout to stop motors on signal loss.
  - Added a joystick deadzone.
  - Implemented a reset for the integral accumulator (PWM value) when the joystick is centered or the robot is disarmed, preventing "integral windup".

- **PID_Control_V3.ino:** Refactored to use the dedicated `PIDController` library for cleaner and more maintainable code.
  - Implemented a robust failsafe and joystick deadzone.
  - Uses `pid.reset()` to correctly clear the PID state when the robot is stopped, disarmed, or the signal is lost, ensuring a complete and stable stop.

- **Cleanup:** Removed obsolete V2 and corrected firmware files to avoid confusion.